### PR TITLE
Prepare for 0.0.1 release

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,4 +1,4 @@
+name: Quarkus ORAS
 release:
-  current-version: "0"
-  next-version: "999-SNAPSHOT"
-
+  current-version: "0.0.1"
+  next-version: "0.0.2-SNAPSHOT"


### PR DESCRIPTION
Update version

From what I understood of https://github.com/quarkiverse/quarkiverse-release

The mapping must be added on https://github.com/quarkiverse/quarkiverse-release/blob/main/quarkiverse-mapping.properties via the workflow https://github.com/quarkiverse/quarkiverse-release/actions/workflows/update-mapping.yml

