### PR TITLE
Add support for spinning op zot registries as devservice containers

### DIFF
--- a/deployment/pom.xml
+++ b/deployment/pom.xml
@@ -22,6 +22,10 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-devservices-deployment</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
       <artifactId>quarkus-junit5-internal</artifactId>
       <scope>test</scope>
     </dependency>

--- a/deployment/src/main/java/io/quarkiverse/oras/deployment/OrasDevServicesConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/oras/deployment/OrasDevServicesConfig.java
@@ -11,12 +11,6 @@ import io.smallrye.config.WithDefault;
 @ConfigMapping(prefix = "quarkus.oras.devservices")
 @ConfigRoot(phase = ConfigPhase.BUILD_TIME)
 public interface OrasDevServicesConfig {
-    /**
-     * If DevServices has been explicitly enabled or disabled. By default,
-     * DevServices are enabled if the DevServices extension is enabled.
-     */
-    @WithDefault("true")
-    boolean enabled();
 
     /**
      * The container image name to use, for the Zot registry
@@ -33,8 +27,9 @@ public interface OrasDevServicesConfig {
 
     /**
      * Indicates if the registry container should be shared or reused.
-     * Defaults to true.
+     * Defaults to false.
      */
-    @WithDefault("true")
+    @WithDefault("false")
     boolean reuse();
+
 }

--- a/deployment/src/main/java/io/quarkiverse/oras/deployment/OrasDevServicesConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/oras/deployment/OrasDevServicesConfig.java
@@ -1,0 +1,40 @@
+package io.quarkiverse.oras.deployment;
+
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
+
+/**
+ * DevServices configuration for ORAS registry containers
+ */
+@ConfigMapping(prefix = "quarkus.oras.devservices")
+@ConfigRoot(phase = ConfigPhase.BUILD_TIME)
+public interface OrasDevServicesConfig {
+    /**
+     * If DevServices has been explicitly enabled or disabled. By default,
+     * DevServices are enabled if the DevServices extension is enabled.
+     */
+    @WithDefault("true")
+    boolean enabled();
+
+    /**
+     * The container image name to use, for the Zot registry
+     */
+    @WithDefault("ghcr.io/project-zot/zot-linux-amd64:v2.1.3")
+    String imageName();
+
+    /**
+     * The base port for registry containers (default: 5000).
+     * For multiple registries, ports will be assigned sequentially starting from this base.
+     */
+    @WithDefault("5000")
+    int basePort();
+
+    /**
+     * Indicates if the registry container should be shared or reused.
+     * Defaults to true.
+     */
+    @WithDefault("true")
+    boolean reuse();
+}

--- a/deployment/src/main/java/io/quarkiverse/oras/deployment/RegistryProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/oras/deployment/RegistryProcessor.java
@@ -162,10 +162,6 @@ class RegistryProcessor {
     @BuildStep(onlyIfNot = IsNormal.class, onlyIf = DevServicesConfig.Enabled.class)
     public DevServicesResultBuildItem createContainer(RegistriesBuildConfiguration registriesConfig,
             OrasDevServicesConfig devServicesConfig) {
-        if (!devServicesConfig.enabled()) {
-            LOG.debug("Dev services for ORAS registries are disabled.");
-            return null; // No dev service to create
-        }
 
         int basePort = devServicesConfig.basePort();
 
@@ -180,8 +176,8 @@ class RegistryProcessor {
         int portOffset = 0;
 
         for (Map.Entry<String, RegistryBuildConfiguration> entry : registriesConfig.names().entrySet()) {
-            if (!entry.getValue().enabled()) {
-                LOG.debug("Skipping disabled registry: {}", entry.getKey());
+            if (!entry.getValue().enabled() || !entry.getValue().devservice()) {
+                LOG.debug("Skipping devservice for registry: {}", entry.getKey());
                 continue; // Skip disabled registries
             }
             String registryName = entry.getKey();

--- a/deployment/src/main/java/io/quarkiverse/oras/deployment/RegistryProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/oras/deployment/RegistryProcessor.java
@@ -19,16 +19,19 @@ import io.quarkiverse.oras.runtime.RegistryBuildConfiguration;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
 import io.quarkus.arc.processor.DotNames;
+import io.quarkus.deployment.IsNormal;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
+import io.quarkus.deployment.builditem.DevServicesResultBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.IndexDependencyBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedPackageBuildItem;
+import io.quarkus.deployment.dev.devservices.DevServicesConfig;
 import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
 import io.quarkus.maven.dependency.ArtifactCoords;
 import io.quarkus.maven.dependency.Dependency;
@@ -154,6 +157,63 @@ class RegistryProcessor {
     void runtimePackages(BuildProducer<RuntimeInitializedPackageBuildItem> packagesProducer) {
         packagesProducer.produce(new RuntimeInitializedPackageBuildItem(
                 "com.github.luben.zstd"));
+    }
+
+    @BuildStep(onlyIfNot = IsNormal.class, onlyIf = DevServicesConfig.Enabled.class)
+    public DevServicesResultBuildItem createContainer(RegistriesBuildConfiguration registriesConfig,
+            OrasDevServicesConfig devServicesConfig) {
+        if (!devServicesConfig.enabled()) {
+            LOG.debug("Dev services for ORAS registries are disabled.");
+            return null; // No dev service to create
+        }
+
+        int basePort = devServicesConfig.basePort();
+
+        // If no registry entries are defined, don't create any containers
+        if (registriesConfig.names().isEmpty()) {
+            return null; // No containers to create
+        }
+
+        // Create a container for each registry entry
+        Map<String, String> configOverrides = new java.util.HashMap<>();
+        java.util.List<ZotContainer> containers = new java.util.ArrayList<>();
+        int portOffset = 0;
+
+        for (Map.Entry<String, RegistryBuildConfiguration> entry : registriesConfig.names().entrySet()) {
+            if (!entry.getValue().enabled()) {
+                LOG.debug("Skipping disabled registry: {}", entry.getKey());
+                continue; // Skip disabled registries
+            }
+            String registryName = entry.getKey();
+            int port = basePort + portOffset++;
+
+            ZotContainer container = new ZotContainer(devServicesConfig.imageName(), port).withReuse(devServicesConfig.reuse());
+            container.start();
+            containers.add(container);
+
+            // Create configuration overrides for each registry
+            configOverrides.put("quarkus.oras.registries." + registryName + ".host", container.getRegistry());
+            configOverrides.put("quarkus.oras.registries." + registryName + ".secure", "false");
+        }
+
+        // Get the ID of the first container as the primary ID
+        String primaryContainerId = containers.get(0).getContainerId();
+
+        // Create a combined close action for all containers as a Closeable
+        java.io.Closeable closeAction = () -> {
+            for (ZotContainer container : containers) {
+                try {
+                    container.close();
+                } catch (Exception e) {
+                    LOG.warn("Failed to stop container: " + e.getMessage(), e);
+                }
+            }
+        };
+
+        return new DevServicesResultBuildItem.RunningDevService(FEATURE,
+                primaryContainerId,
+                closeAction,
+                configOverrides).toBuildItem();
     }
 
     private static <T> SyntheticBeanBuildItem createRegistryBuildItem(

--- a/deployment/src/main/java/io/quarkiverse/oras/deployment/ZotContainer.java
+++ b/deployment/src/main/java/io/quarkiverse/oras/deployment/ZotContainer.java
@@ -1,0 +1,56 @@
+package io.quarkiverse.oras.deployment;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.MountableFile;
+
+public class ZotContainer extends GenericContainer<ZotContainer> {
+
+    private final int containerPort;
+
+    public ZotContainer(String imageName, int containerPort) {
+        super(imageName);
+        this.containerPort = containerPort;
+        addExposedPort(containerPort);
+        // Wait for the catalog endpoint to be available (should return 200 without auth)
+        setWaitStrategy(Wait.forHttp("/v2/_catalog").forPort(containerPort).forStatusCode(200));
+
+        try {
+            // Zot config file
+            Path configFile = Files.createTempFile("zot-config", ".json");
+            String configJson = """
+                          {
+                            "storage": { "rootDirectory": "/var/lib/registry" },
+                            "http": {
+                              "address": "0.0.0.0",
+                              "port": %s
+                            },
+                            "extensions": {
+                              "search": { "enable": true }
+                            }
+                          }
+                    """.formatted(containerPort);
+
+            Files.writeString(configFile, configJson);
+
+            // Copy it into the container
+            withCopyFileToContainer(
+                    MountableFile.forHostPath(configFile.toAbsolutePath().toString()), "/etc/zot/config.json");
+
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to create Zot config", e);
+        }
+    }
+
+    /**
+     * Get the registry URL
+     *
+     * @return The registry URL
+     */
+    public String getRegistry() {
+        return getHost() + ":" + getMappedPort(containerPort);
+    }
+}

--- a/integration-tests/src/main/java/io/quarkiverse/oras/it/OrasResource.java
+++ b/integration-tests/src/main/java/io/quarkiverse/oras/it/OrasResource.java
@@ -34,6 +34,9 @@ public class OrasResource {
     @OrasRegistry("docker")
     Registry docker;
 
+    @OrasRegistry("devs")
+    Registry devServiceRegistry;
+
     @Inject
     OCILayouts ociLayouts;
 
@@ -81,6 +84,13 @@ public class OrasResource {
     @Produces(MediaType.APPLICATION_JSON)
     public List<String> getTags() {
         return docker.getTags(ContainerRef.parse("library/alpine:latest")).tags();
+    }
+
+    @GET
+    @Path("/devservice/get-repositories")
+    @Produces(MediaType.APPLICATION_JSON)
+    public List<String> getDevserviceRepositories() {
+        return devServiceRegistry.getRepositories().repositories();
     }
 
 }

--- a/integration-tests/src/main/resources/application.properties
+++ b/integration-tests/src/main/resources/application.properties
@@ -1,14 +1,21 @@
 quarkus.oras.registries.docker.enabled=true
 quarkus.oras.registries.docker.host=docker.io
+quarkus.oras.registries.docker.devservice=false
 
 quarkus.oras.registries.samples.enabled=true
 quarkus.oras.registries.samples.host=localhost:5000
+quarkus.oras.registries.samples.devservice=false
 
 quarkus.oras.registries.foo.enabled=true
 quarkus.oras.registries.foo.host=localhost:5001
+quarkus.oras.registries.foo.devservice=false
 
 quarkus.oras.registries.bar.enabled=true
 quarkus.oras.registries.bar.host=localhost:5002
+quarkus.oras.registries.bar.devservice=false
+
+quarkus.oras.registries.devs.enabled=true
+quarkus.oras.registries.devs.devservice=true
 
 quarkus.oras.layouts.path=target/test-layouts
 

--- a/integration-tests/src/test/java/io/quarkiverse/oras/it/OrasResourceTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/oras/it/OrasResourceTest.java
@@ -46,4 +46,9 @@ public class OrasResourceTest {
         given().when().get("/oras/compress-zstd").then().statusCode(200).body(is("ok"));
     }
 
+    @Test
+    void testRegistryWithDevservice() {
+        given().when().get("/oras/devservice/get-repositories").then().statusCode(200);
+    }
+
 }

--- a/runtime/src/main/java/io/quarkiverse/oras/runtime/RegistryBuildConfiguration.java
+++ b/runtime/src/main/java/io/quarkiverse/oras/runtime/RegistryBuildConfiguration.java
@@ -15,4 +15,12 @@ public interface RegistryBuildConfiguration {
     @WithDefault("true")
     boolean enabled();
 
+    /**
+     * An optional boolean to enable devserice for the registry.
+     * Defaults to `true`
+     *
+     * @asciidoclet
+     */
+    @WithDefault("true")
+    boolean devservice();
 }


### PR DESCRIPTION
Should implement devservices requested in #40 