### PR TITLE
Add SNAPSHOT repositories

### DIFF
--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -94,4 +94,16 @@
       </build>
     </profile>
   </profiles>
+  <repositories>
+    <repository>
+        <id>central-snapshots</id>
+        <url>https://central.sonatype.com/repository/maven-snapshots/</url>
+        <releases>
+            <enabled>false</enabled>
+        </releases>
+        <snapshots>
+            <enabled>true</enabled>
+        </snapshots>
+    </repository>
+  </repositories>
 </project>


### PR DESCRIPTION
In order to test extension with published SNAPSHOT version of ORAS Java SDK